### PR TITLE
Changed Firebase hosting port from 5000 to 4999

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -33,7 +33,7 @@
       "port": 8080
     },
     "hosting": {
-      "port": 5000
+      "port": 4999
     },
     "pubsub": {
       "port": 8085


### PR DESCRIPTION
As highlighted in #26, the default Firebase hosting port (5000) conflicts with the AirPlay Receiver process on macOS computers. Changing the port in `firebase.json` to any other port resolves the issue.

## Changes
 - Changed the default Firebase hosting port to `4999` from `5000`

## Additional Notes
From now on, we need to explicitly mention the new port in any documentation that uses Firebase hosting, to prevent confusion or miscommunication